### PR TITLE
Fix transcoding video isses.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 *pgm
 build/*
-small_bunny_1080p_60fps.mp4
-bunny_1080p_60fps.mp4
+*.mp4

--- a/2_transcoding.c
+++ b/2_transcoding.c
@@ -338,27 +338,8 @@ static int select_channel_layout(const AVCodec *codec)
 
 static int prepare_audio_copy(TranscodeContext *encoder_context, TranscodeContext *decoder_context) {
   int index = decoder_context->audio_stream_index;
-  encoder_context->codec[index] = avcodec_find_encoder(decoder_context->codec_context[index]->codec_id);
-
-  encoder_context->codec_context[index] = avcodec_alloc_context3(encoder_context->codec[index]);
-  encoder_context->codec_context[index]->sample_rate = decoder_context->codec_context[index]->sample_rate;
-  encoder_context->codec_context[index]->sample_fmt = encoder_context->codec[index]->sample_fmts[0];
-  encoder_context->codec_context[index]->channel_layout = select_channel_layout(encoder_context->codec[index]);
-  encoder_context->codec_context[index]->channels = av_get_channel_layout_nb_channels(encoder_context->codec_context[index]->channel_layout);
-
   encoder_context->stream[index] = avformat_new_stream(encoder_context->format_context, NULL);
-  //encoder_context->time_base = (AVRational){1, encoder_context->sample_rate};
-  encoder_context->stream[index]->time_base = encoder_context->codec_context[index]->time_base;
-
-  if (avcodec_parameters_from_context(encoder_context->stream[index]->codecpar, encoder_context->codec_context[index]) < 0) {
-    logging("failed to copy encoder parameters to output stream");
-    return -1;
-
-  }
-  if (avcodec_open2(encoder_context->codec_context[index], encoder_context->codec[index], NULL) < 0) {
-    logging("failed to open codec through avcodec_open2");
-    return -1;
-  }
+  avcodec_parameters_copy(encoder_context->stream[index]->codecpar, decoder_context->stream[index]->codecpar);
 
   return 0;
 }

--- a/2_transcoding.c
+++ b/2_transcoding.c
@@ -292,7 +292,6 @@ static int prepare_video_encoder(TranscodeContext *encoder_context, TranscodeCon
 
   encoder_codec_context->height = decoder_context->codec_context[index]->height;
   encoder_codec_context->width = decoder_context->codec_context[index]->width;
-  encoder_codec_context->time_base = av_inv_q(decoder_context->codec_context[index]->framerate);
   encoder_codec_context->sample_aspect_ratio = decoder_context->codec_context[index]->sample_aspect_ratio;
 
   if (encoder_context->codec[index]->pix_fmts)

--- a/2_transcoding.c
+++ b/2_transcoding.c
@@ -245,9 +245,9 @@ static int encode_frame(TranscodeContext *decoder_context, TranscodeContext *enc
     output_packet->stream_index = stream_index;
 
     av_packet_rescale_ts(output_packet,
-        decoder_context->codec_context[stream_index]->time_base,
-        encoder_context->stream[stream_index]->time_base
-        );
+        decoder_context->stream[stream_index]->time_base,
+        encoder_context->stream[stream_index]->time_base);
+
     /* mux encoded frame */
     ret = av_interleaved_write_frame(format_context, output_packet);
 


### PR DESCRIPTION
This PR fixes the issue that the clip plays at an excessively slow pace, due to erroneous time scaling.
Additionally audio wasn't passed correctly, due to the encoder being created before the audio stream.