### PR TITLE
[WIP] Add the transcoding chapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 build/*
 small_bunny_1080p_60fps.mp4
 bunny_1080p_60fps.mp4
+bunny_1s_gop.mp4
+bunny_h265.mp4

--- a/3_0_transmuxing.c
+++ b/3_0_transmuxing.c
@@ -1,0 +1,212 @@
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <libavutil/opt.h>
+#include <string.h>
+#include <inttypes.h>
+
+static void logging(const char *fmt, ...)
+{
+  va_list args;
+  fprintf( stderr, "LOG: " );
+  va_start( args, fmt );
+  vfprintf( stderr, fmt, args );
+  va_end( args );
+  fprintf( stderr, "\n" );
+}
+
+void print_timing(char *name, AVFormatContext *avf, AVCodecContext *avc, AVStream *avs) {
+  logging("=================================================");
+  logging("%s", name);
+
+  logging("\tAVFormatContext");
+  if (avf != NULL) {
+    logging("\t\tstart_time=%d duration=%d bit_rate=%d start_time_realtime=%d", avf->start_time, avf->duration, avf->bit_rate, avf->start_time_realtime);
+  } else {
+    logging("\t\t->NULL");
+  }
+
+  logging("\tAVCodecContext");
+  if (avc != NULL) {
+    logging("\t\tbit_rate=%d ticks_per_frame=%d width=%d height=%d gop_size=%d keyint_min=%d sample_rate=%d profile=%d level=%d ",
+        avc->bit_rate, avc->ticks_per_frame, avc->width, avc->height, avc->gop_size, avc->keyint_min, avc->sample_rate, avc->profile, avc->level);
+    logging("\t\tavc->time_base=num/den %d/%d", avc->time_base.num, avc->time_base.den);
+    logging("\t\tavc->framerate=num/den %d/%d", avc->framerate.num, avc->framerate.den);
+    logging("\t\tavc->pkt_timebase=num/den %d/%d", avc->pkt_timebase.num, avc->pkt_timebase.den);
+  } else {
+    logging("\t\t->NULL");
+  }
+
+  logging("\tAVStream");
+  if (avs != NULL) {
+    logging("\t\tindex=%d start_time=%d duration=%d ", avs->index, avs->start_time, avs->duration);
+    logging("\t\tavs->time_base=num/den %d/%d", avs->time_base.num, avs->time_base.den);
+    logging("\t\tavs->sample_aspect_ratio=num/den %d/%d", avs->sample_aspect_ratio.num, avs->sample_aspect_ratio.den);
+    logging("\t\tavs->avg_frame_rate=num/den %d/%d", avs->avg_frame_rate.num, avs->avg_frame_rate.den);
+    logging("\t\tavs->r_frame_rate=num/den %d/%d", avs->r_frame_rate.num, avs->r_frame_rate.den);
+  } else {
+    logging("\t\t->NULL");
+  }
+
+  logging("=================================================");
+}
+
+int fill_stream_info(AVStream *avs, AVCodec **avc, AVCodecContext **avcc) {
+  //https://www.ffmpeg.org/doxygen/trunk/group__lavc__decoding.html#ga19a0ca553277f019dd5b0fec6e1f9dca
+  // Find a registered decoder with a matching codec ID.
+  *avc = avcodec_find_decoder(avs->codecpar->codec_id);
+  if (!*avc) {logging("failed to find the codec"); return -1;}
+
+  //https://www.ffmpeg.org/doxygen/trunk/group__lavc__core.html#gae80afec6f26df6607eaacf39b561c315
+  // Allocate an AVCodecContext and set its fields to default values.
+  *avcc = avcodec_alloc_context3(*avc);
+  if (!*avcc) {logging("failed to alloc memory for codec context"); return -1;}
+
+  //https://www.ffmpeg.org/doxygen/trunk/group__lavc__core.html#gac7b282f51540ca7a99416a3ba6ee0d16
+  // Fill the codec context based on the values from the supplied codec parameters.
+  if (avcodec_parameters_to_context(*avcc, avs->codecpar) < 0) {logging("failed to fill codec context"); return -1;}
+
+  //https://www.ffmpeg.org/doxygen/trunk/group__lavc__core.html#ga11f785a188d7d9df71621001465b0f1d
+  // Initialize the AVCodecContext to use the given AVCodec.
+  if (avcodec_open2(*avcc, *avc, NULL) < 0) {logging("failed to open codec"); return -1;}
+  return 0;
+}
+
+int main(int argc, char *argv[])
+{
+  char *in_filename = argv[1];
+  char *out_filename =argv[2];
+  //av_log_set_level(AV_LOG_DEBUG);
+
+  AVFormatContext *decoder_avfc = NULL;
+  AVFormatContext *encoder_avfc = NULL;
+
+  //https://www.ffmpeg.org/doxygen/trunk/group__lavf__core.html#gac7a91abf2f59648d995894711f070f62
+  // allocating memory for enc avformat
+  decoder_avfc = avformat_alloc_context();
+  if (!decoder_avfc) {logging("failed to alloc memory for format"); return -1;}
+
+  //https://www.ffmpeg.org/doxygen/trunk/group__lavf__decoding.html#gaff468dcc45289542f4c30d311bc2a201
+  // opening the file for the format
+  if (avformat_open_input(&decoder_avfc, in_filename, NULL, NULL) != 0) {logging("failed to open input file %s", in_filename); return -1;}
+
+  //https://www.ffmpeg.org/doxygen/trunk/group__lavf__decoding.html#gad42172e27cddafb81096939783b157bb
+  // reading bytes from file to get stream info
+  if (avformat_find_stream_info(decoder_avfc, NULL) < 0) {logging("failed to get stream info"); return -1;}
+
+  /*
+   * Prepping the decoder
+   */
+  AVCodec *decoder_video_codec, *decoder_audio_codec;
+  AVStream *decoder_video_avs, *decoder_audio_avs;
+  AVCodecContext *decoder_video_avcc, *decoder_audio_avcc;
+
+  // iterating through all the input streams (audio, video, subtitles and etc)
+  // if we have multiples streams of audio and video we're going to take the last
+  for (int i = 0; i < decoder_avfc->nb_streams; i++) {
+    if (decoder_avfc->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
+      // keeping a pointer to the video av stream
+      decoder_video_avs = decoder_avfc->streams[i];
+
+      fill_stream_info(decoder_video_avs, &decoder_video_codec, &decoder_video_avcc);
+      print_timing("Video timming info from the decoder preparation", decoder_avfc, decoder_video_avcc, decoder_video_avs);
+    } else if (decoder_avfc->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_AUDIO) {
+      // keeping a pointer to the audio av stream
+      decoder_audio_avs = decoder_avfc->streams[i];
+
+      fill_stream_info(decoder_audio_avs, &decoder_audio_codec, &decoder_audio_avcc);
+      print_timing("Audio timming info from the decoder preparation", decoder_avfc, decoder_audio_avcc, decoder_audio_avs);
+    } else {
+      logging("skipping streams other than audio and video");
+    }
+  }
+
+  /*
+   * Prepping the encoder
+   */
+  AVCodec *encoder_video_codec = NULL, *encoder_audio_codec = NULL;
+  AVStream *encoder_video_avs = NULL, *encoder_audio_avs = NULL;
+  AVCodecContext *encoder_video_avcc = NULL, *encoder_audio_avcc = NULL;
+
+  //https://www.ffmpeg.org/doxygen/trunk/avformat_8h.html#a0234fa1116af3c0a72edaa08a2ba304f
+  // Allocate an AVFormatContext for an output format.
+  avformat_alloc_output_context2(&encoder_avfc, NULL, NULL, out_filename);
+  if (!encoder_avfc) {logging("could not allocate memory for output format");return -1;}
+
+  // prepping video to be copied
+  encoder_video_avs = avformat_new_stream(encoder_avfc, NULL);
+  //https://www.ffmpeg.org/doxygen/trunk/group__lavc__core.html#ga6d02e640ccc12c783841ce51d09b9fa7
+  // Any allocated fields in dst are freed and replaced with newly allocated duplicates of the corresponding fields in src.
+  avcodec_parameters_copy(encoder_video_avs->codecpar, decoder_video_avs->codecpar);
+  print_timing("Video timming info from the encoder preparation", encoder_avfc, encoder_video_avcc, encoder_video_avs);
+
+  // prepping audio to be copied
+  encoder_audio_avs = avformat_new_stream(encoder_avfc, NULL);
+  //https://www.ffmpeg.org/doxygen/trunk/group__lavc__core.html#ga6d02e640ccc12c783841ce51d09b9fa7
+  // Any allocated fields in dst are freed and replaced with newly allocated duplicates of the corresponding fields in src.
+  avcodec_parameters_copy(encoder_audio_avs->codecpar, decoder_audio_avs->codecpar);
+  print_timing("Audio timming info from the encoder preparation", encoder_avfc, encoder_audio_avcc, encoder_audio_avs);
+
+
+  if (encoder_avfc->oformat->flags & AVFMT_GLOBALHEADER)
+    //https://www.ffmpeg.org/doxygen/trunk/group__lavc__core.html#ga9ed82634c59b339786575827c47a8f68
+    // Place global headers in extradata instead of every keyframe.
+    encoder_avfc->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+
+  if (!(encoder_avfc->oformat->flags & AVFMT_NOFILE)) {
+    //https://www.ffmpeg.org/doxygen/trunk/aviobuf_8c.html#ab1b99c5b70aa59f15ab7cd4cbb40381e
+    // Create and initialize a AVIOContext for accessing the resource indicated by url.
+    if (avio_open(&encoder_avfc->pb, out_filename, AVIO_FLAG_WRITE) < 0) {
+      logging("could not open the output file");
+      return -1;
+    }
+  }
+  //https://www.ffmpeg.org/doxygen/trunk/group__lavf__encoding.html#ga18b7b10bb5b94c4842de18166bc677cb
+  // Allocate the stream private data and write the stream header to an output media file.
+  if (avformat_write_header(encoder_avfc, NULL) < 0) {logging("an error occurred when opening output file"); return -1;}
+
+
+  AVFrame *input_frame = av_frame_alloc();
+  if (!input_frame) {logging("failed to allocated memory for AVFrame"); return -1;}
+
+  AVPacket *input_packet = av_packet_alloc();
+  if (!input_packet) {logging("failed to allocated memory for AVPacket"); return -1;}
+
+  int response = 0;
+
+  //https://www.ffmpeg.org/doxygen/trunk/group__lavf__decoding.html#ga4fdb3084415a82e3810de6ee60e46a61
+  // Return the next frame of a stream.
+  while (av_read_frame(decoder_avfc, input_packet) >= 0)
+  {
+    if (decoder_avfc->streams[input_packet->stream_index]->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
+      //https://www.ffmpeg.org/doxygen/trunk/group__lavc__packet.html#gae5c86e4d93f6e7aa62ef2c60763ea67e
+      // Convert valid timing fields (timestamps / durations) in a packet from one timebase to another.
+      av_packet_rescale_ts(input_packet, decoder_avfc->streams[input_packet->stream_index]->time_base, encoder_avfc->streams[input_packet->stream_index]->time_base);
+
+      //https://www.ffmpeg.org/doxygen/trunk/group__lavf__encoding.html#ga37352ed2c63493c38219d935e71db6c1
+      // Write a packet to an output media file ensuring correct interleaving
+      if (av_interleaved_write_frame(encoder_avfc, input_packet) < 0) { logging("error while copying stream packet"); return -1; }
+    } else if (decoder_avfc->streams[input_packet->stream_index]->codecpar->codec_type == AVMEDIA_TYPE_AUDIO)  {
+      //https://www.ffmpeg.org/doxygen/trunk/group__lavc__packet.html#gae5c86e4d93f6e7aa62ef2c60763ea67e
+      // Convert valid timing fields (timestamps / durations) in a packet from one timebase to another.
+      av_packet_rescale_ts(input_packet, decoder_avfc->streams[input_packet->stream_index]->time_base, encoder_avfc->streams[input_packet->stream_index]->time_base);
+
+      //https://www.ffmpeg.org/doxygen/trunk/group__lavf__encoding.html#ga37352ed2c63493c38219d935e71db6c1
+      // Write a packet to an output media file ensuring correct interleaving
+      if (av_interleaved_write_frame(encoder_avfc, input_packet) < 0) { logging("error while copying stream packet"); return -1; }
+    } else {
+      logging("ignoring all non video or audio packets");
+    }
+  }
+  //https://www.ffmpeg.org/doxygen/trunk/group__lavf__encoding.html#ga7f14007e7dc8f481f054b21614dfec13
+  // Write the stream trailer to an output media file and free the file private data.
+  av_write_trailer(encoder_avfc);
+
+  // TODO: we should free everything!
+  //avformat_free_context(decoder_avfc);
+  //avformat_free_context(encoder_avfc);
+  return 0;
+}
+

--- a/3_1_transmuxing_fmp4.c
+++ b/3_1_transmuxing_fmp4.c
@@ -1,0 +1,217 @@
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <libavutil/opt.h>
+#include <string.h>
+#include <inttypes.h>
+
+static void logging(const char *fmt, ...)
+{
+  va_list args;
+  fprintf( stderr, "LOG: " );
+  va_start( args, fmt );
+  vfprintf( stderr, fmt, args );
+  va_end( args );
+  fprintf( stderr, "\n" );
+}
+
+void print_timing(char *name, AVFormatContext *avf, AVCodecContext *avc, AVStream *avs) {
+  logging("=================================================");
+  logging("%s", name);
+
+  logging("\tAVFormatContext");
+  if (avf != NULL) {
+    logging("\t\tstart_time=%d duration=%d bit_rate=%d start_time_realtime=%d", avf->start_time, avf->duration, avf->bit_rate, avf->start_time_realtime);
+  } else {
+    logging("\t\t->NULL");
+  }
+
+  logging("\tAVCodecContext");
+  if (avc != NULL) {
+    logging("\t\tbit_rate=%d ticks_per_frame=%d width=%d height=%d gop_size=%d keyint_min=%d sample_rate=%d profile=%d level=%d ",
+        avc->bit_rate, avc->ticks_per_frame, avc->width, avc->height, avc->gop_size, avc->keyint_min, avc->sample_rate, avc->profile, avc->level);
+    logging("\t\tavc->time_base=num/den %d/%d", avc->time_base.num, avc->time_base.den);
+    logging("\t\tavc->framerate=num/den %d/%d", avc->framerate.num, avc->framerate.den);
+    logging("\t\tavc->pkt_timebase=num/den %d/%d", avc->pkt_timebase.num, avc->pkt_timebase.den);
+  } else {
+    logging("\t\t->NULL");
+  }
+
+  logging("\tAVStream");
+  if (avs != NULL) {
+    logging("\t\tindex=%d start_time=%d duration=%d ", avs->index, avs->start_time, avs->duration);
+    logging("\t\tavs->time_base=num/den %d/%d", avs->time_base.num, avs->time_base.den);
+    logging("\t\tavs->sample_aspect_ratio=num/den %d/%d", avs->sample_aspect_ratio.num, avs->sample_aspect_ratio.den);
+    logging("\t\tavs->avg_frame_rate=num/den %d/%d", avs->avg_frame_rate.num, avs->avg_frame_rate.den);
+    logging("\t\tavs->r_frame_rate=num/den %d/%d", avs->r_frame_rate.num, avs->r_frame_rate.den);
+  } else {
+    logging("\t\t->NULL");
+  }
+
+  logging("=================================================");
+}
+
+int fill_stream_info(AVStream *avs, AVCodec **avc, AVCodecContext **avcc) {
+  //https://www.ffmpeg.org/doxygen/trunk/group__lavc__decoding.html#ga19a0ca553277f019dd5b0fec6e1f9dca
+  // Find a registered decoder with a matching codec ID.
+  *avc = avcodec_find_decoder(avs->codecpar->codec_id);
+  if (!*avc) {logging("failed to find the codec"); return -1;}
+
+  //https://www.ffmpeg.org/doxygen/trunk/group__lavc__core.html#gae80afec6f26df6607eaacf39b561c315
+  // Allocate an AVCodecContext and set its fields to default values.
+  *avcc = avcodec_alloc_context3(*avc);
+  if (!*avcc) {logging("failed to alloc memory for codec context"); return -1;}
+
+  //https://www.ffmpeg.org/doxygen/trunk/group__lavc__core.html#gac7b282f51540ca7a99416a3ba6ee0d16
+  // Fill the codec context based on the values from the supplied codec parameters.
+  if (avcodec_parameters_to_context(*avcc, avs->codecpar) < 0) {logging("failed to fill codec context"); return -1;}
+
+  //https://www.ffmpeg.org/doxygen/trunk/group__lavc__core.html#ga11f785a188d7d9df71621001465b0f1d
+  // Initialize the AVCodecContext to use the given AVCodec.
+  if (avcodec_open2(*avcc, *avc, NULL) < 0) {logging("failed to open codec"); return -1;}
+  return 0;
+}
+
+int main(int argc, char *argv[])
+{
+  char *in_filename = argv[1];
+  char *out_filename =argv[2];
+  //av_log_set_level(AV_LOG_DEBUG);
+
+  AVFormatContext *decoder_avfc = NULL;
+  AVFormatContext *encoder_avfc = NULL;
+
+  //https://www.ffmpeg.org/doxygen/trunk/group__lavf__core.html#gac7a91abf2f59648d995894711f070f62
+  // allocating memory for enc avformat
+  decoder_avfc = avformat_alloc_context();
+  if (!decoder_avfc) {logging("failed to alloc memory for format"); return -1;}
+
+  //https://www.ffmpeg.org/doxygen/trunk/group__lavf__decoding.html#gaff468dcc45289542f4c30d311bc2a201
+  // opening the file for the format
+  if (avformat_open_input(&decoder_avfc, in_filename, NULL, NULL) != 0) {logging("failed to open input file %s", in_filename); return -1;}
+
+  //https://www.ffmpeg.org/doxygen/trunk/group__lavf__decoding.html#gad42172e27cddafb81096939783b157bb
+  // reading bytes from file to get stream info
+  if (avformat_find_stream_info(decoder_avfc, NULL) < 0) {logging("failed to get stream info"); return -1;}
+
+  /*
+   * Prepping the decoder
+   */
+  AVCodec *decoder_video_codec, *decoder_audio_codec;
+  AVStream *decoder_video_avs, *decoder_audio_avs;
+  AVCodecContext *decoder_video_avcc, *decoder_audio_avcc;
+
+  // iterating through all the input streams (audio, video, subtitles and etc)
+  // if we have multiples streams of audio and video we're going to take the last
+  for (int i = 0; i < decoder_avfc->nb_streams; i++) {
+    if (decoder_avfc->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
+      // keeping a pointer to the video av stream
+      decoder_video_avs = decoder_avfc->streams[i];
+
+      fill_stream_info(decoder_video_avs, &decoder_video_codec, &decoder_video_avcc);
+      print_timing("Video timming info from the decoder preparation", decoder_avfc, decoder_video_avcc, decoder_video_avs);
+    } else if (decoder_avfc->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_AUDIO) {
+      // keeping a pointer to the audio av stream
+      decoder_audio_avs = decoder_avfc->streams[i];
+
+      fill_stream_info(decoder_audio_avs, &decoder_audio_codec, &decoder_audio_avcc);
+      print_timing("Audio timming info from the decoder preparation", decoder_avfc, decoder_audio_avcc, decoder_audio_avs);
+    } else {
+      logging("skipping streams other than audio and video");
+    }
+  }
+
+  /*
+   * Prepping the encoder
+   */
+  AVCodec *encoder_video_codec = NULL, *encoder_audio_codec = NULL;
+  AVStream *encoder_video_avs = NULL, *encoder_audio_avs = NULL;
+  AVCodecContext *encoder_video_avcc = NULL, *encoder_audio_avcc = NULL;
+
+  //https://www.ffmpeg.org/doxygen/trunk/avformat_8h.html#a0234fa1116af3c0a72edaa08a2ba304f
+  // Allocate an AVFormatContext for an output format.
+  avformat_alloc_output_context2(&encoder_avfc, NULL, NULL, out_filename);
+  if (!encoder_avfc) {logging("could not allocate memory for output format");return -1;}
+
+  // prepping video to be copied
+  encoder_video_avs = avformat_new_stream(encoder_avfc, NULL);
+  //https://www.ffmpeg.org/doxygen/trunk/group__lavc__core.html#ga6d02e640ccc12c783841ce51d09b9fa7
+  // Any allocated fields in dst are freed and replaced with newly allocated duplicates of the corresponding fields in src.
+  avcodec_parameters_copy(encoder_video_avs->codecpar, decoder_video_avs->codecpar);
+  print_timing("Video timming info from the encoder preparation", encoder_avfc, encoder_video_avcc, encoder_video_avs);
+
+  // prepping audio to be copied
+  encoder_audio_avs = avformat_new_stream(encoder_avfc, NULL);
+  //https://www.ffmpeg.org/doxygen/trunk/group__lavc__core.html#ga6d02e640ccc12c783841ce51d09b9fa7
+  // Any allocated fields in dst are freed and replaced with newly allocated duplicates of the corresponding fields in src.
+  avcodec_parameters_copy(encoder_audio_avs->codecpar, decoder_audio_avs->codecpar);
+  print_timing("Audio timming info from the encoder preparation", encoder_avfc, encoder_audio_avcc, encoder_audio_avs);
+
+
+  if (encoder_avfc->oformat->flags & AVFMT_GLOBALHEADER)
+    //https://www.ffmpeg.org/doxygen/trunk/group__lavc__core.html#ga9ed82634c59b339786575827c47a8f68
+    // Place global headers in extradata instead of every keyframe.
+    encoder_avfc->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+
+  if (!(encoder_avfc->oformat->flags & AVFMT_NOFILE)) {
+    //https://www.ffmpeg.org/doxygen/trunk/aviobuf_8c.html#ab1b99c5b70aa59f15ab7cd4cbb40381e
+    // Create and initialize a AVIOContext for accessing the resource indicated by url.
+    if (avio_open(&encoder_avfc->pb, out_filename, AVIO_FLAG_WRITE) < 0) {
+      logging("could not open the output file");
+      return -1;
+    }
+  }
+  // adding options to the muxer
+  AVDictionary* muxer_opts = NULL;
+  // https://developer.mozilla.org/en-US/docs/Web/API/Media_Source_Extensions_API/Transcoding_assets_for_MSE
+  av_dict_set(&muxer_opts, "movflags", "frag_keyframe+empty_moov+default_base_moof", 0);
+
+  //https://www.ffmpeg.org/doxygen/trunk/group__lavf__encoding.html#ga18b7b10bb5b94c4842de18166bc677cb
+  // Allocate the stream private data and write the stream header to an output media file.
+  if (avformat_write_header(encoder_avfc, &muxer_opts) < 0) {logging("an error occurred when opening output file"); return -1;}
+
+
+  AVFrame *input_frame = av_frame_alloc();
+  if (!input_frame) {logging("failed to allocated memory for AVFrame"); return -1;}
+
+  AVPacket *input_packet = av_packet_alloc();
+  if (!input_packet) {logging("failed to allocated memory for AVPacket"); return -1;}
+
+  int response = 0;
+
+  //https://www.ffmpeg.org/doxygen/trunk/group__lavf__decoding.html#ga4fdb3084415a82e3810de6ee60e46a61
+  // Return the next frame of a stream.
+  while (av_read_frame(decoder_avfc, input_packet) >= 0)
+  {
+    if (decoder_avfc->streams[input_packet->stream_index]->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
+      //https://www.ffmpeg.org/doxygen/trunk/group__lavc__packet.html#gae5c86e4d93f6e7aa62ef2c60763ea67e
+      // Convert valid timing fields (timestamps / durations) in a packet from one timebase to another.
+      av_packet_rescale_ts(input_packet, decoder_avfc->streams[input_packet->stream_index]->time_base, encoder_avfc->streams[input_packet->stream_index]->time_base);
+
+      //https://www.ffmpeg.org/doxygen/trunk/group__lavf__encoding.html#ga37352ed2c63493c38219d935e71db6c1
+      // Write a packet to an output media file ensuring correct interleaving
+      if (av_interleaved_write_frame(encoder_avfc, input_packet) < 0) { logging("error while copying stream packet"); return -1; }
+    } else if (decoder_avfc->streams[input_packet->stream_index]->codecpar->codec_type == AVMEDIA_TYPE_AUDIO)  {
+      //https://www.ffmpeg.org/doxygen/trunk/group__lavc__packet.html#gae5c86e4d93f6e7aa62ef2c60763ea67e
+      // Convert valid timing fields (timestamps / durations) in a packet from one timebase to another.
+      av_packet_rescale_ts(input_packet, decoder_avfc->streams[input_packet->stream_index]->time_base, encoder_avfc->streams[input_packet->stream_index]->time_base);
+
+      //https://www.ffmpeg.org/doxygen/trunk/group__lavf__encoding.html#ga37352ed2c63493c38219d935e71db6c1
+      // Write a packet to an output media file ensuring correct interleaving
+      if (av_interleaved_write_frame(encoder_avfc, input_packet) < 0) { logging("error while copying stream packet"); return -1; }
+    } else {
+      logging("ignoring all non video or audio packets");
+    }
+  }
+  //https://www.ffmpeg.org/doxygen/trunk/group__lavf__encoding.html#ga7f14007e7dc8f481f054b21614dfec13
+  // Write the stream trailer to an output media file and free the file private data.
+  av_write_trailer(encoder_avfc);
+
+  // TODO: we should free everything!
+  //avformat_free_context(decoder_avfc);
+  //avformat_free_context(encoder_avfc);
+  return 0;
+}
+

--- a/3_transcoding_gop.c
+++ b/3_transcoding_gop.c
@@ -25,8 +25,8 @@ static int encode_frame(TranscodeContext *decoder_context, TranscodeContext *enc
 static int prepare_decoder(TranscodeContext *decoder_context);
 static int prepare_encoder(TranscodeContext *encoder_context, TranscodeContext *decoder_context);
 
-// it was create to debug the timming issues
-void print_timming(char *name, AVFormatContext *avf, AVCodecContext *avc, AVStream *avs) {
+// it was create to debug the timing issues
+void print_timing(char *name, AVFormatContext *avf, AVCodecContext *avc, AVStream *avs) {
   logging("=================================================");
   logging("%s", name);
 
@@ -118,6 +118,7 @@ int main(int argc, char *argv[])
           encoder_context->stream[input_packet->stream_index]->time_base
           );
 
+
       if (av_interleaved_write_frame(encoder_context->format_context, input_packet) < 0) {
         logging("error while copying audio stream");
         return -1;
@@ -203,7 +204,7 @@ static int prepare_decoder(TranscodeContext *decoder_context) {
       logging("failed to open codec through avcodec_open2");
       return -1;
     }
-    print_timming("decoder", decoder_context->format_context, decoder_context->codec_context[i], decoder_context->stream[i]);
+    print_timing("decoder", decoder_context->format_context, decoder_context->codec_context[i], decoder_context->stream[i]);
   }
 
   return 0;
@@ -389,14 +390,14 @@ static int prepare_encoder(TranscodeContext *encoder_context, TranscodeContext *
     return -1;
   }
   logging("Video");
-  print_timming("encoder", encoder_context->format_context, encoder_context->codec_context[encoder_context->video_stream_index], encoder_context->stream[encoder_context->video_stream_index]);
+  print_timing("encoder", encoder_context->format_context, encoder_context->codec_context[decoder_context->video_stream_index], encoder_context->stream[decoder_context->video_stream_index]);
 
   if (prepare_audio_copy(encoder_context, decoder_context)) {
     logging("error while preparing audio copy");
     return -1;
   }
   logging("Audio");
-  print_timming("encoder", encoder_context->format_context, encoder_context->codec_context[encoder_context->audio_stream_index], encoder_context->stream[encoder_context->audio_stream_index]);
+  print_timing("encoder", encoder_context->format_context, encoder_context->codec_context[decoder_context->audio_stream_index], encoder_context->stream[decoder_context->audio_stream_index]);
 
   if (encoder_context->format_context->oformat->flags & AVFMT_GLOBALHEADER)
     encoder_context->format_context->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;

--- a/3_transcoding_gop.c
+++ b/3_transcoding_gop.c
@@ -330,7 +330,17 @@ static int prepare_video_encoder(TranscodeContext *encoder_context, TranscodeCon
   else
     encoder_context->codec_context[index]->pix_fmt = decoder_context->codec_context[index]->pix_fmt;
 
-  encoder_context->codec_context[index]->time_base = decoder_context->stream[index]->time_base;
+  encoder_context->codec_context[index]->time_base = decoder_context->stream[index]->avg_frame_rate;
+
+//  encoder_context->codec_context[index]->ticks_per_frame = decoder_context->codec_context[index]->ticks_per_frame;
+//  encoder_context->codec_context[index]->level = decoder_context->codec_context[index]->level;
+//  encoder_context->codec_context[index]->profile = decoder_context->codec_context[index]->profile;
+//
+//  encoder_context->stream[index]->sample_aspect_ratio = decoder_context->stream[index]->sample_aspect_ratio;
+//  encoder_context->stream[index]->time_base = decoder_context->stream[index]->time_base;
+//  encoder_context->stream[index]->duration = decoder_context->stream[index]->duration;
+//  encoder_context->stream[index]->avg_frame_rate = decoder_context->stream[index]->avg_frame_rate;
+//  encoder_context->stream[index]->r_frame_rate = decoder_context->stream[index]->r_frame_rate;
 
   if (avcodec_open2(encoder_context->codec_context[index], encoder_context->codec[index], &encoder_options) < 0) {
     logging("could not open the codec");
@@ -342,10 +352,6 @@ static int prepare_video_encoder(TranscodeContext *encoder_context, TranscodeCon
     return -1;
   }
 
-
-
-
-  encoder_context->stream[index]->time_base = encoder_context->codec_context[index]->time_base;
   return 0;
 }
 

--- a/3_transcoding_gop.c
+++ b/3_transcoding_gop.c
@@ -241,6 +241,9 @@ static int encode_frame(TranscodeContext *decoder_context, TranscodeContext *enc
 
     /* prepare packet for muxing */
     output_packet->stream_index = stream_index;
+    // you need to set the package duration otherwise
+    // it might present fps/dts/pts issues (thanks James and Vassilis from mailing list)
+    output_packet->duration = format_context->streams[stream_index]->time_base.den / format_context->streams[stream_index]->time_base.num / decoder_context->stream[stream_index]->avg_frame_rate.num * decoder_context->stream[stream_index]->avg_frame_rate.den;
 
     av_packet_rescale_ts(output_packet,
         decoder_context->stream[stream_index]->time_base,

--- a/3_transcoding_gop.c
+++ b/3_transcoding_gop.c
@@ -1,0 +1,377 @@
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <libavutil/opt.h>
+#include <string.h>
+#include <inttypes.h>
+
+typedef struct _TranscodeContext {
+  char *file_name;
+  AVFormatContext *format_context;
+
+  AVCodec *codec[2];
+  AVStream *stream[2];
+  AVCodecParameters *codec_parameters[2];
+  AVCodecContext *codec_context[2];
+  int video_stream_index;
+  int audio_stream_index;
+} TranscodeContext;
+
+static void logging(const char *fmt, ...);
+static int decode_packet(TranscodeContext *decoder_context, TranscodeContext *encoder_context, AVPacket *packet, AVFrame *frame, int stream_index);
+static int encode_frame(TranscodeContext *decoder_context, TranscodeContext *encoder_context, AVFormatContext *format_context, AVCodecContext *codec_context, AVFrame *frame, int stream_index);
+static int prepare_decoder(TranscodeContext *decoder_context);
+static int prepare_encoder(TranscodeContext *encoder_context, TranscodeContext *decoder_context);
+
+int main(int argc, char *argv[])
+{
+  TranscodeContext *decoder_context = calloc(1, sizeof(TranscodeContext));
+  decoder_context->file_name = argv[1];
+
+  if (prepare_decoder(decoder_context)) {
+    logging("error while preparing input");
+    return -1;
+  }
+
+  TranscodeContext *encoder_context = calloc(1, sizeof(TranscodeContext));
+  encoder_context->file_name = argv[2];
+
+  if (prepare_encoder(encoder_context, decoder_context)) {
+    logging("error while preparing output");
+    return -1;
+  }
+
+  AVFrame *input_frame = av_frame_alloc();
+  if (!input_frame) {
+    logging("failed to allocated memory for AVFrame");
+    return -1;
+  }
+  AVPacket *input_packet = av_packet_alloc();
+  if (!input_packet) {
+    logging("failed to allocated memory for AVPacket");
+    return -1;
+  }
+
+  int response = 0;
+  int how_many_packets_to_process = 20;
+
+  while (av_read_frame(decoder_context->format_context, input_packet) >= 0)
+  {
+    //logging("AVPacket->pts %" PRId64, input_packet->pts);
+
+    if (input_packet->stream_index == decoder_context->video_stream_index) {
+      response = decode_packet(
+          decoder_context,
+          encoder_context,
+          input_packet,
+          input_frame,
+          input_packet->stream_index
+          );
+
+      if (response < 0)
+        break;
+      //if (--how_many_packets_to_process <= 0) break;
+      av_packet_unref(input_packet);
+    } else {
+      // just copying audio stream
+      av_packet_rescale_ts(input_packet,
+          decoder_context->stream[input_packet->stream_index]->time_base,
+          encoder_context->stream[input_packet->stream_index]->time_base
+          );
+
+      if (av_interleaved_write_frame(encoder_context->format_context, input_packet) < 0) {
+        logging("error while copying audio stream");
+        return -1;
+      }
+      //logging("\tfinish copying packets without reencoding");
+    }
+  }
+  // flush all frames
+  encode_frame(decoder_context, encoder_context, encoder_context->format_context, encoder_context->codec_context[encoder_context->video_stream_index], NULL, encoder_context->video_stream_index);
+  // should I do it for the audio stream too?
+
+  av_write_trailer(encoder_context->format_context);
+
+  logging("releasing all the resources");
+
+  avformat_close_input(&decoder_context->format_context);
+  avformat_free_context(decoder_context->format_context);
+  av_packet_free(&input_packet);
+  av_frame_free(&input_frame);
+  avcodec_free_context(&decoder_context->codec_context[0]);
+  avcodec_free_context(&decoder_context->codec_context[1]);
+  free(decoder_context);
+  return 0;
+}
+
+static void logging(const char *fmt, ...)
+{
+  va_list args;
+  fprintf( stderr, "LOG: " );
+  va_start( args, fmt );
+  vfprintf( stderr, fmt, args );
+  va_end( args );
+  fprintf( stderr, "\n" );
+}
+
+static int prepare_decoder(TranscodeContext *decoder_context) {
+  decoder_context->format_context = avformat_alloc_context();
+  if (!decoder_context->format_context) {
+    logging("ERROR could not allocate memory for Format Context");
+    return -1;
+  }
+
+  if (avformat_open_input(&decoder_context->format_context, decoder_context->file_name, NULL, NULL) != 0) {
+    logging("ERROR could not open the file");
+    return -1;
+  }
+
+  if (avformat_find_stream_info(decoder_context->format_context,  NULL) < 0) {
+    logging("ERROR could not get the stream info");
+    return -1;
+  }
+
+  for (int i = 0; i < decoder_context->format_context->nb_streams; i++)
+  {
+    if (decoder_context->format_context->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
+      decoder_context->video_stream_index = i;
+      logging("Video");
+    } else if (decoder_context->format_context->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_AUDIO) {
+      decoder_context->audio_stream_index = i;
+      logging("Audio");
+    }
+    decoder_context->codec_parameters[i] = decoder_context->format_context->streams[i]->codecpar;
+    decoder_context->stream[i] = decoder_context->format_context->streams[i];
+
+    logging("\tAVStream->time_base before open coded %d/%d", decoder_context->stream[i]->time_base.num, decoder_context->stream[i]->time_base.den);
+    logging("\tAVStream->r_frame_rate before open coded %d/%d", decoder_context->stream[i]->r_frame_rate.num, decoder_context->stream[i]->r_frame_rate.den);
+    logging("\tAVStream->start_time %" PRId64, decoder_context->stream[i]->start_time);
+    logging("\tAVStream->duration %" PRId64, decoder_context->stream[i]->duration);
+
+    decoder_context->codec[i] = avcodec_find_decoder(decoder_context->codec_parameters[i]->codec_id);
+    if (!decoder_context->codec[i]) {
+      logging("ERROR unsupported codec!");
+      return -1;
+    }
+
+    decoder_context->codec_context[i] = avcodec_alloc_context3(decoder_context->codec[i]);
+    if (!decoder_context->codec[i]) {
+      logging("failed to allocated memory for AVCodecContext");
+      return -1;
+    }
+
+    if (avcodec_parameters_to_context(decoder_context->codec_context[i], decoder_context->codec_parameters[i]) < 0) {
+      logging("failed to copy codec params to codec context");
+      return -1;
+    }
+
+    if (avcodec_open2(decoder_context->codec_context[i], decoder_context->codec[i], NULL) < 0) {
+      logging("failed to open codec through avcodec_open2");
+      return -1;
+    }
+  }
+
+  return 0;
+}
+
+static int decode_packet(TranscodeContext *decoder_context, TranscodeContext *encoder_context, AVPacket *packet, AVFrame *frame, int stream_index)
+{
+  AVCodecContext *codec_context = decoder_context->codec_context[stream_index];
+
+  int response = avcodec_send_packet(codec_context, packet);
+
+  if (response < 0) {
+    logging("DECODER: Error while sending a packet to the decoder: %s", av_err2str(response));
+    return response;
+  }
+
+  while (response >= 0)
+  {
+    response = avcodec_receive_frame(codec_context, frame);
+    if (response == AVERROR(EAGAIN) || response == AVERROR_EOF) {
+      break;
+    } else if (response < 0) {
+      logging("DECODER: Error while receiving a frame from the decoder: %s", av_err2str(response));
+      return response;
+    }
+
+    if (response >= 0) {
+      if (codec_context->codec_type == AVMEDIA_TYPE_VIDEO) {
+       // logging(
+       //     "\tEncoding VIDEO Frame %d (type=%c, size=%d bytes) pts %d key_frame %d [DTS %d]",
+       //     codec_context->frame_number,
+       //     av_get_picture_type_char(frame->pict_type),
+       //     frame->pkt_size,
+       //     frame->pts,
+       //     frame->key_frame,
+       //     frame->coded_picture_number
+       //     );
+        encode_frame(decoder_context, encoder_context, encoder_context->format_context, encoder_context->codec_context[stream_index], frame, stream_index);
+      }
+      av_frame_unref(frame);
+    }
+  }
+  return 0;
+}
+
+static int encode_frame(TranscodeContext *decoder_context, TranscodeContext *encoder_context, AVFormatContext *format_context, AVCodecContext *codec_context, AVFrame *frame, int stream_index)
+{
+  AVPacket *output_packet = av_packet_alloc();
+  if (!output_packet) {
+    logging("could not allocate memory for output packet");
+    return -1;
+  }
+
+  int ret;
+  if (frame)
+    //logging("Send frame %3"PRId64"", frame->pts);
+  ret = avcodec_send_frame(codec_context, frame);
+
+  while (ret >= 0) {
+    ret = avcodec_receive_packet(codec_context, output_packet);
+
+    if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) {
+      break;
+    } else if (ret < 0) {
+      logging("ENCODING: Error while receiving a packet from the encoder: %s", av_err2str(ret));
+      return -1;
+    }
+
+    /* prepare packet for muxing */
+    output_packet->stream_index = stream_index;
+
+    av_packet_rescale_ts(output_packet,
+        decoder_context->stream[stream_index]->time_base,
+        encoder_context->stream[stream_index]->time_base);
+
+    /* mux encoded frame */
+    ret = av_interleaved_write_frame(format_context, output_packet);
+
+    if (ret != 0) {
+      logging("Error %d while receiving a packet from the decoder: %s", ret, av_err2str(ret));
+    }
+
+    //logging("Write packet %d (size=%d)", output_packet->pts, output_packet->size);
+  }
+  av_packet_unref(output_packet);
+  av_packet_free(&output_packet);
+  return 0;
+}
+
+
+static int prepare_video_encoder(TranscodeContext *encoder_context, TranscodeContext *decoder_context) {
+  int index = decoder_context->video_stream_index;
+  encoder_context->stream[index] = avformat_new_stream(encoder_context->format_context, NULL);
+  encoder_context->codec[index] = avcodec_find_encoder_by_name("libx264");
+
+  if (!encoder_context->codec[index]) {
+    logging("could not find the proper codec");
+    return -1;
+  }
+
+  encoder_context->codec_context[index] = avcodec_alloc_context3(encoder_context->codec[index]);
+  if (!encoder_context->codec_context[index]) {
+    logging("could not allocated memory for codec context");
+    return -1;
+  }
+
+  // why, when and how is this useful?
+  AVDictionary *encoder_options = NULL;
+
+  AVCodecContext *encoder_codec_context = encoder_context->codec_context[index];
+  av_opt_set(encoder_context->codec_context[index]->priv_data, "preset", "fast", 0);
+  av_opt_set(encoder_context->codec_context[index]->priv_data, "x264opts", "keyint=60:min-keyint=60:scenecut=-1", 0);
+
+  encoder_codec_context->height = decoder_context->codec_context[index]->height;
+  encoder_codec_context->width = decoder_context->codec_context[index]->width;
+  encoder_codec_context->sample_aspect_ratio = decoder_context->codec_context[index]->sample_aspect_ratio;
+
+  if (encoder_context->codec[index]->pix_fmts)
+    encoder_context->codec_context[index]->pix_fmt = encoder_context->codec[index]->pix_fmts[0];
+  else
+    encoder_context->codec_context[index]->pix_fmt = decoder_context->codec_context[index]->pix_fmt;
+
+  encoder_context->codec_context[index]->time_base = decoder_context->stream[index]->time_base;
+
+  if (avcodec_open2(encoder_context->codec_context[index], encoder_context->codec[index], &encoder_options) < 0) {
+    logging("could not open the codec");
+    return -1;
+  }
+
+  if (avcodec_parameters_from_context(encoder_context->stream[index]->codecpar, encoder_context->codec_context[index]) < 0) {
+    logging("could not copy encoder parameters to output stream");
+    return -1;
+  }
+
+
+
+
+  encoder_context->stream[index]->time_base = encoder_context->codec_context[index]->time_base;
+  return 0;
+}
+
+static int select_channel_layout(const AVCodec *codec)
+{
+  const uint64_t *p;
+  uint64_t best_ch_layout = 0;
+  int best_nb_channels = 0;
+  if (!codec->channel_layouts)
+    return AV_CH_LAYOUT_STEREO;
+  p = codec->channel_layouts;
+  while (*p)
+  {
+    int nb_channels = av_get_channel_layout_nb_channels(*p);
+    if (nb_channels > best_nb_channels)
+    {
+      best_ch_layout = *p;
+      best_nb_channels = nb_channels;
+    }
+    p++;
+  }
+  return best_ch_layout;
+}
+
+static int prepare_audio_copy(TranscodeContext *encoder_context, TranscodeContext *decoder_context) {
+  int index = decoder_context->audio_stream_index;
+  encoder_context->stream[index] = avformat_new_stream(encoder_context->format_context, NULL);
+  avcodec_parameters_copy(encoder_context->stream[index]->codecpar, decoder_context->stream[index]->codecpar);
+
+  return 0;
+}
+
+static int prepare_encoder(TranscodeContext *encoder_context, TranscodeContext *decoder_context) {
+  avformat_alloc_output_context2(&encoder_context->format_context, NULL, NULL, encoder_context->file_name);
+  if (!encoder_context->format_context) {
+    logging("could not allocate memory for output format");
+    return -1;
+  }
+
+  if (prepare_video_encoder(encoder_context, decoder_context)) {
+    logging("error while preparing video encoder");
+    return -1;
+  }
+
+  if (prepare_audio_copy(encoder_context, decoder_context)) {
+    logging("error while preparing audio copy");
+    return -1;
+  }
+
+  if (encoder_context->format_context->oformat->flags & AVFMT_GLOBALHEADER)
+    encoder_context->format_context->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+
+  if (!(encoder_context->format_context->oformat->flags & AVFMT_NOFILE)) {
+    if (avio_open(&encoder_context->format_context->pb, encoder_context->file_name, AVIO_FLAG_WRITE) < 0) {
+      logging("could not open the output file");
+      return -1;
+    }
+  }
+  if (avformat_write_header(encoder_context->format_context, NULL) < 0) {
+    logging("an error occurred when opening output file");
+    return -1;
+  }
+
+  return 0;
+}
+

--- a/3_transcoding_h265.c
+++ b/3_transcoding_h265.c
@@ -241,6 +241,9 @@ static int encode_frame(TranscodeContext *decoder_context, TranscodeContext *enc
 
     /* prepare packet for muxing */
     output_packet->stream_index = stream_index;
+    // you need to set the package duration otherwise
+    // it might present fps/dts/pts issues (thanks James and Vassilis from mailing list)
+    output_packet->duration = format_context->streams[stream_index]->time_base.den / format_context->streams[stream_index]->time_base.num / decoder_context->stream[stream_index]->avg_frame_rate.num * decoder_context->stream[stream_index]->avg_frame_rate.den;
 
     av_packet_rescale_ts(output_packet,
         decoder_context->stream[stream_index]->time_base,

--- a/3_transcoding_h265.c
+++ b/3_transcoding_h265.c
@@ -297,7 +297,7 @@ static int prepare_video_encoder(TranscodeContext *encoder_context, TranscodeCon
   else
     encoder_context->codec_context[index]->pix_fmt = decoder_context->codec_context[index]->pix_fmt;
 
-  encoder_context->codec_context[index]->time_base = decoder_context->stream[index]->time_base;
+  encoder_context->codec_context[index]->time_base = decoder_context->stream[index]->avg_frame_rate;
 
   if (avcodec_open2(encoder_context->codec_context[index], encoder_context->codec[index], &encoder_options) < 0) {
     logging("could not open the codec");

--- a/3_transcoding_h265.c
+++ b/3_transcoding_h265.c
@@ -1,0 +1,378 @@
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <libavutil/opt.h>
+#include <string.h>
+#include <inttypes.h>
+
+typedef struct _TranscodeContext {
+  char *file_name;
+  AVFormatContext *format_context;
+
+  AVCodec *codec[2];
+  AVStream *stream[2];
+  AVCodecParameters *codec_parameters[2];
+  AVCodecContext *codec_context[2];
+  int video_stream_index;
+  int audio_stream_index;
+} TranscodeContext;
+
+static void logging(const char *fmt, ...);
+static int decode_packet(TranscodeContext *decoder_context, TranscodeContext *encoder_context, AVPacket *packet, AVFrame *frame, int stream_index);
+static int encode_frame(TranscodeContext *decoder_context, TranscodeContext *encoder_context, AVFormatContext *format_context, AVCodecContext *codec_context, AVFrame *frame, int stream_index);
+static int prepare_decoder(TranscodeContext *decoder_context);
+static int prepare_encoder(TranscodeContext *encoder_context, TranscodeContext *decoder_context);
+
+int main(int argc, char *argv[])
+{
+  TranscodeContext *decoder_context = calloc(1, sizeof(TranscodeContext));
+  decoder_context->file_name = argv[1];
+
+  if (prepare_decoder(decoder_context)) {
+    logging("error while preparing input");
+    return -1;
+  }
+
+  TranscodeContext *encoder_context = calloc(1, sizeof(TranscodeContext));
+  encoder_context->file_name = argv[2];
+
+  if (prepare_encoder(encoder_context, decoder_context)) {
+    logging("error while preparing output");
+    return -1;
+  }
+
+  AVFrame *input_frame = av_frame_alloc();
+  if (!input_frame) {
+    logging("failed to allocated memory for AVFrame");
+    return -1;
+  }
+  AVPacket *input_packet = av_packet_alloc();
+  if (!input_packet) {
+    logging("failed to allocated memory for AVPacket");
+    return -1;
+  }
+
+  int response = 0;
+  int how_many_packets_to_process = 20;
+
+  while (av_read_frame(decoder_context->format_context, input_packet) >= 0)
+  {
+    //logging("AVPacket->pts %" PRId64, input_packet->pts);
+
+    if (input_packet->stream_index == decoder_context->video_stream_index) {
+      response = decode_packet(
+          decoder_context,
+          encoder_context,
+          input_packet,
+          input_frame,
+          input_packet->stream_index
+          );
+
+      if (response < 0)
+        break;
+      //if (--how_many_packets_to_process <= 0) break;
+      av_packet_unref(input_packet);
+    } else {
+      // just copying audio stream
+      av_packet_rescale_ts(input_packet,
+          decoder_context->stream[input_packet->stream_index]->time_base,
+          encoder_context->stream[input_packet->stream_index]->time_base
+          );
+
+      if (av_interleaved_write_frame(encoder_context->format_context, input_packet) < 0) {
+        logging("error while copying audio stream");
+        return -1;
+      }
+      //logging("\tfinish copying packets without reencoding");
+    }
+  }
+  // flush all frames
+  encode_frame(decoder_context, encoder_context, encoder_context->format_context, encoder_context->codec_context[encoder_context->video_stream_index], NULL, encoder_context->video_stream_index);
+  // should I do it for the audio stream too?
+
+  av_write_trailer(encoder_context->format_context);
+
+  logging("releasing all the resources");
+
+  avformat_close_input(&decoder_context->format_context);
+  avformat_free_context(decoder_context->format_context);
+  av_packet_free(&input_packet);
+  av_frame_free(&input_frame);
+  avcodec_free_context(&decoder_context->codec_context[0]);
+  avcodec_free_context(&decoder_context->codec_context[1]);
+  free(decoder_context);
+  return 0;
+}
+
+static void logging(const char *fmt, ...)
+{
+  va_list args;
+  fprintf( stderr, "LOG: " );
+  va_start( args, fmt );
+  vfprintf( stderr, fmt, args );
+  va_end( args );
+  fprintf( stderr, "\n" );
+}
+
+static int prepare_decoder(TranscodeContext *decoder_context) {
+  decoder_context->format_context = avformat_alloc_context();
+  if (!decoder_context->format_context) {
+    logging("ERROR could not allocate memory for Format Context");
+    return -1;
+  }
+
+  if (avformat_open_input(&decoder_context->format_context, decoder_context->file_name, NULL, NULL) != 0) {
+    logging("ERROR could not open the file");
+    return -1;
+  }
+
+  if (avformat_find_stream_info(decoder_context->format_context,  NULL) < 0) {
+    logging("ERROR could not get the stream info");
+    return -1;
+  }
+
+  for (int i = 0; i < decoder_context->format_context->nb_streams; i++)
+  {
+    if (decoder_context->format_context->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
+      decoder_context->video_stream_index = i;
+      logging("Video");
+    } else if (decoder_context->format_context->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_AUDIO) {
+      decoder_context->audio_stream_index = i;
+      logging("Audio");
+    }
+    decoder_context->codec_parameters[i] = decoder_context->format_context->streams[i]->codecpar;
+    decoder_context->stream[i] = decoder_context->format_context->streams[i];
+
+    logging("\tAVStream->time_base before open coded %d/%d", decoder_context->stream[i]->time_base.num, decoder_context->stream[i]->time_base.den);
+    logging("\tAVStream->r_frame_rate before open coded %d/%d", decoder_context->stream[i]->r_frame_rate.num, decoder_context->stream[i]->r_frame_rate.den);
+    logging("\tAVStream->start_time %" PRId64, decoder_context->stream[i]->start_time);
+    logging("\tAVStream->duration %" PRId64, decoder_context->stream[i]->duration);
+
+    decoder_context->codec[i] = avcodec_find_decoder(decoder_context->codec_parameters[i]->codec_id);
+    if (!decoder_context->codec[i]) {
+      logging("ERROR unsupported codec!");
+      return -1;
+    }
+
+    decoder_context->codec_context[i] = avcodec_alloc_context3(decoder_context->codec[i]);
+    if (!decoder_context->codec[i]) {
+      logging("failed to allocated memory for AVCodecContext");
+      return -1;
+    }
+
+    if (avcodec_parameters_to_context(decoder_context->codec_context[i], decoder_context->codec_parameters[i]) < 0) {
+      logging("failed to copy codec params to codec context");
+      return -1;
+    }
+
+    if (avcodec_open2(decoder_context->codec_context[i], decoder_context->codec[i], NULL) < 0) {
+      logging("failed to open codec through avcodec_open2");
+      return -1;
+    }
+  }
+
+  return 0;
+}
+
+static int decode_packet(TranscodeContext *decoder_context, TranscodeContext *encoder_context, AVPacket *packet, AVFrame *frame, int stream_index)
+{
+  AVCodecContext *codec_context = decoder_context->codec_context[stream_index];
+
+  int response = avcodec_send_packet(codec_context, packet);
+
+  if (response < 0) {
+    logging("DECODER: Error while sending a packet to the decoder: %s", av_err2str(response));
+    return response;
+  }
+
+  while (response >= 0)
+  {
+    response = avcodec_receive_frame(codec_context, frame);
+    if (response == AVERROR(EAGAIN) || response == AVERROR_EOF) {
+      break;
+    } else if (response < 0) {
+      logging("DECODER: Error while receiving a frame from the decoder: %s", av_err2str(response));
+      return response;
+    }
+
+    if (response >= 0) {
+      if (codec_context->codec_type == AVMEDIA_TYPE_VIDEO) {
+       // logging(
+       //     "\tEncoding VIDEO Frame %d (type=%c, size=%d bytes) pts %d key_frame %d [DTS %d]",
+       //     codec_context->frame_number,
+       //     av_get_picture_type_char(frame->pict_type),
+       //     frame->pkt_size,
+       //     frame->pts,
+       //     frame->key_frame,
+       //     frame->coded_picture_number
+       //     );
+        encode_frame(decoder_context, encoder_context, encoder_context->format_context, encoder_context->codec_context[stream_index], frame, stream_index);
+      }
+      av_frame_unref(frame);
+    }
+  }
+  return 0;
+}
+
+static int encode_frame(TranscodeContext *decoder_context, TranscodeContext *encoder_context, AVFormatContext *format_context, AVCodecContext *codec_context, AVFrame *frame, int stream_index)
+{
+  AVPacket *output_packet = av_packet_alloc();
+  if (!output_packet) {
+    logging("could not allocate memory for output packet");
+    return -1;
+  }
+
+  int ret;
+  if (frame)
+    //logging("Send frame %3"PRId64"", frame->pts);
+  ret = avcodec_send_frame(codec_context, frame);
+
+  while (ret >= 0) {
+    ret = avcodec_receive_packet(codec_context, output_packet);
+
+    if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) {
+      break;
+    } else if (ret < 0) {
+      logging("ENCODING: Error while receiving a packet from the encoder: %s", av_err2str(ret));
+      return -1;
+    }
+
+    /* prepare packet for muxing */
+    output_packet->stream_index = stream_index;
+
+    av_packet_rescale_ts(output_packet,
+        decoder_context->stream[stream_index]->time_base,
+        encoder_context->stream[stream_index]->time_base);
+
+    /* mux encoded frame */
+    ret = av_interleaved_write_frame(format_context, output_packet);
+
+    if (ret != 0) {
+      logging("Error %d while receiving a packet from the decoder: %s", ret, av_err2str(ret));
+    }
+
+    //logging("Write packet %d (size=%d)", output_packet->pts, output_packet->size);
+  }
+  av_packet_unref(output_packet);
+  av_packet_free(&output_packet);
+  return 0;
+}
+
+
+static int prepare_video_encoder(TranscodeContext *encoder_context, TranscodeContext *decoder_context) {
+  int index = decoder_context->video_stream_index;
+  encoder_context->stream[index] = avformat_new_stream(encoder_context->format_context, NULL);
+  encoder_context->codec[index] = avcodec_find_encoder_by_name("libx265");
+
+  if (!encoder_context->codec[index]) {
+    logging("could not find the proper codec");
+    return -1;
+  }
+
+  encoder_context->codec_context[index] = avcodec_alloc_context3(encoder_context->codec[index]);
+  if (!encoder_context->codec_context[index]) {
+    logging("could not allocated memory for codec context");
+    return -1;
+  }
+
+  // why, when and how is this useful?
+  AVDictionary *encoder_options = NULL;
+
+  AVCodecContext *encoder_codec_context = encoder_context->codec_context[index];
+  av_opt_set(encoder_context->codec_context[index]->priv_data, "preset", "slow", 0);
+  av_opt_set(encoder_context->codec_context[index]->priv_data, "x265-params", "keyint=60:min-keyint=60:scenecut=0", 0);
+  av_opt_set(encoder_context->codec_context[index]->priv_data, "crf", "22", 0);
+
+  encoder_codec_context->height = decoder_context->codec_context[index]->height;
+  encoder_codec_context->width = decoder_context->codec_context[index]->width;
+  encoder_codec_context->sample_aspect_ratio = decoder_context->codec_context[index]->sample_aspect_ratio;
+
+  if (encoder_context->codec[index]->pix_fmts)
+    encoder_context->codec_context[index]->pix_fmt = encoder_context->codec[index]->pix_fmts[0];
+  else
+    encoder_context->codec_context[index]->pix_fmt = decoder_context->codec_context[index]->pix_fmt;
+
+  encoder_context->codec_context[index]->time_base = decoder_context->stream[index]->time_base;
+
+  if (avcodec_open2(encoder_context->codec_context[index], encoder_context->codec[index], &encoder_options) < 0) {
+    logging("could not open the codec");
+    return -1;
+  }
+
+  if (avcodec_parameters_from_context(encoder_context->stream[index]->codecpar, encoder_context->codec_context[index]) < 0) {
+    logging("could not copy encoder parameters to output stream");
+    return -1;
+  }
+
+
+
+
+  encoder_context->stream[index]->time_base = encoder_context->codec_context[index]->time_base;
+  return 0;
+}
+
+static int select_channel_layout(const AVCodec *codec)
+{
+  const uint64_t *p;
+  uint64_t best_ch_layout = 0;
+  int best_nb_channels = 0;
+  if (!codec->channel_layouts)
+    return AV_CH_LAYOUT_STEREO;
+  p = codec->channel_layouts;
+  while (*p)
+  {
+    int nb_channels = av_get_channel_layout_nb_channels(*p);
+    if (nb_channels > best_nb_channels)
+    {
+      best_ch_layout = *p;
+      best_nb_channels = nb_channels;
+    }
+    p++;
+  }
+  return best_ch_layout;
+}
+
+static int prepare_audio_copy(TranscodeContext *encoder_context, TranscodeContext *decoder_context) {
+  int index = decoder_context->audio_stream_index;
+  encoder_context->stream[index] = avformat_new_stream(encoder_context->format_context, NULL);
+  avcodec_parameters_copy(encoder_context->stream[index]->codecpar, decoder_context->stream[index]->codecpar);
+
+  return 0;
+}
+
+static int prepare_encoder(TranscodeContext *encoder_context, TranscodeContext *decoder_context) {
+  avformat_alloc_output_context2(&encoder_context->format_context, NULL, NULL, encoder_context->file_name);
+  if (!encoder_context->format_context) {
+    logging("could not allocate memory for output format");
+    return -1;
+  }
+
+  if (prepare_video_encoder(encoder_context, decoder_context)) {
+    logging("error while preparing video encoder");
+    return -1;
+  }
+
+  if (prepare_audio_copy(encoder_context, decoder_context)) {
+    logging("error while preparing audio copy");
+    return -1;
+  }
+
+  if (encoder_context->format_context->oformat->flags & AVFMT_GLOBALHEADER)
+    encoder_context->format_context->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+
+  if (!(encoder_context->format_context->oformat->flags & AVFMT_NOFILE)) {
+    if (avio_open(&encoder_context->format_context->pb, encoder_context->file_name, AVIO_FLAG_WRITE) < 0) {
+      logging("could not open the output file");
+      return -1;
+    }
+  }
+  if (avformat_write_header(encoder_context->format_context, NULL) < 0) {
+    logging("an error occurred when opening output file");
+    return -1;
+  }
+
+  return 0;
+}
+

--- a/Makefile
+++ b/Makefile
@@ -42,3 +42,12 @@ make_transcoding_h265: clean
 
 run_transcoding_h265: make_transcoding_h265
 	docker run -w /files --rm -it -v `pwd`:/files leandromoreira/ffmpeg-devel ./build/transcoding_h265 /files/small_bunny_1080p_60fps.mp4 /files/bunny_h265.mp4
+
+make_3_0_transmuxing: clean
+	docker run -w /files --rm -it  -v `pwd`:/files leandromoreira/ffmpeg-devel \
+	  gcc -L/opt/ffmpeg/lib -I/opt/ffmpeg/include/ /files/3_0_transmuxing.c \
+	  -lavcodec -lavformat -lavfilter -lavdevice -lswresample -lswscale -lavutil \
+	  -o /files/build/3_0_transmuxing
+
+run_3_0_transmuxing: make_3_0_transmuxing
+	docker run -w /files --rm -it -v `pwd`:/files leandromoreira/ffmpeg-devel ./build/3_0_transmuxing /files/small_bunny_1080p_60fps.mp4 /files/bunny_1s_gop.mp4

--- a/Makefile
+++ b/Makefile
@@ -51,3 +51,12 @@ make_3_0_transmuxing: clean
 
 run_3_0_transmuxing: make_3_0_transmuxing
 	docker run -w /files --rm -it -v `pwd`:/files leandromoreira/ffmpeg-devel ./build/3_0_transmuxing /files/small_bunny_1080p_60fps.mp4 /files/bunny_1s_gop.mp4
+
+make_3_1_transmuxing_fmp4: clean
+	docker run -w /files --rm -it  -v `pwd`:/files leandromoreira/ffmpeg-devel \
+	  gcc -L/opt/ffmpeg/lib -I/opt/ffmpeg/include/ /files/3_1_transmuxing_fmp4.c \
+	  -lavcodec -lavformat -lavfilter -lavdevice -lswresample -lswscale -lavutil \
+	  -o /files/build/3_1_transmuxing_fmp4
+
+run_3_1_transmuxing_fmp4: make_3_1_transmuxing_fmp4
+	docker run -w /files --rm -it -v `pwd`:/files leandromoreira/ffmpeg-devel ./build/3_1_transmuxing_fmp4 /files/small_bunny_1080p_60fps.mp4 /files/bunny_1s_gop.mp4

--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,21 @@ run_remuxing_ts: make_remuxing
 
 run_remuxing_fragmented_mp4: make_remuxing
 	docker run -w /files --rm -it -v `pwd`:/files leandromoreira/ffmpeg-devel /files/build/remuxing /files/small_bunny_1080p_60fps.mp4 /files/fragmented_small_bunny_1080p_60fps.mp4 fragmented
+
+make_transcoding_gop: clean
+	docker run -w /files --rm -it  -v `pwd`:/files leandromoreira/ffmpeg-devel \
+	  gcc -L/opt/ffmpeg/lib -I/opt/ffmpeg/include/ /files/3_transcoding_gop.c \
+	  -lavcodec -lavformat -lavfilter -lavdevice -lswresample -lswscale -lavutil \
+	  -o /files/build/transcoding_gop
+
+run_transcoding_gop: make_transcoding_gop
+	docker run -w /files --rm -it -v `pwd`:/files leandromoreira/ffmpeg-devel ./build/transcoding_gop /files/small_bunny_1080p_60fps.mp4 /files/bunny_1s_gop.mp4
+
+make_transcoding_h265: clean
+	docker run -w /files --rm -it  -v `pwd`:/files leandromoreira/ffmpeg-devel \
+	  gcc -L/opt/ffmpeg/lib -I/opt/ffmpeg/include/ /files/3_transcoding_h265.c \
+	  -lavcodec -lavformat -lavfilter -lavdevice -lswresample -lswscale -lavutil \
+	  -o /files/build/transcoding_h265
+
+run_transcoding_h265: make_transcoding_h265
+	docker run -w /files --rm -it -v `pwd`:/files leandromoreira/ffmpeg-devel ./build/transcoding_h265 /files/small_bunny_1080p_60fps.mp4 /files/bunny_h265.mp4


### PR DESCRIPTION
## tasks/issues to be done

The chapter will demonstrate how to transcoding using libav/ffmpeg. Things we need to be done/fixed before:

- [X] transcode h264 to h264 changing the GOP
- [X] transcode h264 to h265 and changing the GOP
- [X] fix frame rate transcoding issue (thanks Vassilis)
- [x] fix the message `MB rate (125337600) > level limit (2073600)` while transcoding h264 (thanks doom9 people)
- [ ] fix the message `forced frame type (3) at 141 was changed to frame type (1)` while transcoding h264
- [ ] fix the message `specified frame type (5) at 120 is not compatible with keyframe interval` while transcoding h265
- [x] fix the `min_keyint` for h264 not being properly handled (it happens also on command line)
- [ ] create bitrate change example
- [ ] refactor the code
- [ ] describe this examples in textual form

## long explanation

While I'm doing this chapter I'm also trying to understand some issues I found although the main examples seems to be okay, aka the `vlc` is playing it fine:

```bash
# if you want to run them in your computer: make sure you have docker and
# have ran the make fetch_small_bunny_video command to download the bunny video
 
make run_transcoding_gop

make run_transcoding_h265
```

But anyway here are my doubts:

* ✅  Is there a single way to setup GOP and disable scenecut for h264 and h265? (Nope)
>  I tried to use `avcodectxt->gop_size`, `avcodectxt->keyint_min`, `av_opt_set(avcodecctxt->priv_data, "sc_threshold", "0", 0)` but it seemed to work only, partially, for h264 in order to make it work for both I forced the `avcodectxt->priv_data`: `x264` and `x265-params`.
* How can I setup the "CBR" mode, setting a bitrate for h265?
> For `x264` I changed `encoder_codec_context->bit_rate`, `encoder_codec_context->rc_max_rate`, `encoder_codec_context->rc_min_rate` and `encoder_codec_context->rc_buffer_size` but those didn't work for h265.
* ✅  After I transcoded with this code `ffprobe` is showing 60.11  fps but `mediainfo` is showing 60.000fps while the original video has fixed 60fps, why this usually happens? (could be the 250 gop conversion?)
* When the transcoding gop example is running the ffmpeg (libx264) logging shows the messages: ✅ `MB rate (125337600) > level limit (2073600)` and `forced frame type (3) at 141 was changed to frame type (1)` should I be worried about them? or are they just warning because I changed the GOP structure? 
> I tried to keep the original GOP and the `forced frame` message disappeared but the `MB rate` was kept
* When the transcoding h265 example is running the ffmpeg (libx265) logging shows the messages: `specified frame type (5) at 120 is not compatible with keyframe interval` what does it means?
