### PR TITLE
add avregister all before create avFormatContext

### DIFF
--- a/0_hello_world.c
+++ b/0_hello_world.c
@@ -35,6 +35,9 @@ int main(int argc, const char *argv[])
   
   logging("initializing all the containers, codecs and protocols.");
 
+  av_register_all();
+  avcodec_register_all();
+
   // AVFormatContext holds the header information from the format (Container)
   // Allocating memory for this component
   // http://ffmpeg.org/doxygen/trunk/structAVFormatContext.html


### PR DESCRIPTION
Hi just found an issue when i try to run without using docker container.
The issue was avformat_open_input returns error `-1094995529`
Here is the log
```
LOG: initializing all the containers, codecs and protocols.
LOG: opening the input file (2.mp4) and loading format (container) header
LOG: ERROR could not open the file, error code (Invalid data found when processing input)
```
Practically, it was caused because of no muxer/demuxer registerd 
based on this : https://stackoverflow.com/questions/39778605/ffmpeg-avformat-open-input-not-working-invalid-data-found-when-processing-input

to solve it i added 

```
 av_register_all();
  avcodec_register_all();
```