### PR TITLE
Demo code bug fix.

### DIFF
--- a/0_hello_world.c
+++ b/0_hello_world.c
@@ -122,7 +122,7 @@ int main(int argc, const char *argv[])
     }
 
     // print its name, id and bitrate
-    logging("\tCodec %s ID %d bit_rate %lld", pLocalCodec->name, pLocalCodec->id, pCodecParameters->bit_rate);
+    logging("\tCodec %s ID %d bit_rate %lld", pLocalCodec->name, pLocalCodec->id, pLocalCodecParameters->bit_rate);
   }
   // https://ffmpeg.org/doxygen/trunk/structAVCodecContext.html
   AVCodecContext *pCodecContext = avcodec_alloc_context3(pCodec);
@@ -186,7 +186,6 @@ int main(int argc, const char *argv[])
   logging("releasing all the resources");
 
   avformat_close_input(&pFormatContext);
-  avformat_free_context(pFormatContext);
   av_packet_free(&pPacket);
   av_frame_free(&pFrame);
   avcodec_free_context(&pCodecContext);


### PR DESCRIPTION
1. `pCodecParameters` can be NULL. I think it should be `pLocalCodecParameters`.
2. `avformat_close_input` is enough to free a context, calling `avformat_free_context` after it is just wrong:
```c
/**
 * Close an opened input AVFormatContext. Free it and all its contents
 * and set *s to NULL.
 */
void avformat_close_input(AVFormatContext **s);
```