### PR TITLE
tutorial1: fix variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ if (pLocalCodecParameters->codec_type == AVMEDIA_TYPE_VIDEO) {
   printf("Audio Codec: %d channels, sample rate %d", pLocalCodecParameters->channels, pLocalCodecParameters->sample_rate);
 }
 // general
-printf("\tCodec %s ID %d bit_rate %lld", pLocalCodec->long_name, pLocalCodec->id, pCodecParameters->bit_rate);
+printf("\tCodec %s ID %d bit_rate %lld", pLocalCodec->long_name, pLocalCodec->id, pLocalCodecParameters->bit_rate);
 ```
 
 With the codec, we can allocate memory for the [`AVCodecContext`](https://ffmpeg.org/doxygen/trunk/structAVCodecContext.html), which will hold the context for our decode/encode process, but then we need to fill this codec context with CODEC parameters; we do that with [`avcodec_parameters_to_context`](https://ffmpeg.org/doxygen/trunk/group__lavc__core.html#gac7b282f51540ca7a99416a3ba6ee0d16).


### PR DESCRIPTION
Following the script `pCodecParameters` has never been mentioned it's probably tended to be a `pLocalCodecParameters`

thank you for this repository