### PR TITLE
fetch_bbb_video.sh: force using bash

### DIFF
--- a/fetch_bbb_video.sh
+++ b/fetch_bbb_video.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 read -p "WARNING: You're about to download 340MB, are you sure? (yN) " -n 1 -r
 echo    # (optional) move to a new line
 if [[ ! $REPLY =~ ^[Yy]$ ]]


### PR DESCRIPTION
The fetch_bbb_video.sh script uses bash specific constructs
On Ubuntu the default shell is dash.
By adding #!/bin/bash to the script we make sure that bash is used in
that case