### PR TITLE
Ignore unknown codecs in hello_world

### DIFF
--- a/0_hello_world.c
+++ b/0_hello_world.c
@@ -105,7 +105,8 @@ int main(int argc, const char *argv[])
 
     if (pLocalCodec==NULL) {
       logging("ERROR unsupported codec!");
-      return -1;
+      // In this example if the codec is not found we just skip it
+      continue;
     }
 
     // when the stream is a video we store its index, codec parameters and codec


### PR DESCRIPTION
When running hello_world on a transport stream it failed because that
stream contained 4 elementary streams: one for video, one for audio, one
for teletext and one for EPG data (program guide). For the latter no
codec was found.

This change just continues if for a stream no codec is found.
Actually for this sample it would suffice if there is just a video
stream.