### PR TITLE
Fix link to python bindings in documentation

### DIFF
--- a/README-cn.md
+++ b/README-cn.md
@@ -2,7 +2,7 @@
 
 起初我在寻找可以学习使用FFmpeg库(又名 libav)的教程或书籍，然后找到了名为["如何在1k行代码内实现视频播放器"](http://dranger.com/ffmpeg/)的指南。但该项目已经停止维护，因此我决定撰写此教程。
 
-此项目主要使用C语言开发，**但请不用担心**：项目内容非常通俗易懂。FFmpeg libav具有许多其他语言的实现，例如[python](https://mikeboers.github.io/PyAV/)，[go](https://github.com/imkira/go-libav)。即使其中没有你熟悉的编程语言，仍然可以通过  `ffi` 为它提供支持（这是一个 [Lua](https://github.com/daurnimator/ffmpeg-lua-ffi/blob/master/init.lua) 的示例）。
+此项目主要使用C语言开发，**但请不用担心**：项目内容非常通俗易懂。FFmpeg libav具有许多其他语言的实现，例如[python](https://pyav.org/)，[go](https://github.com/imkira/go-libav)。即使其中没有你熟悉的编程语言，仍然可以通过  `ffi` 为它提供支持（这是一个 [Lua](https://github.com/daurnimator/ffmpeg-lua-ffi/blob/master/init.lua) 的示例）。
 
 下文将会简单介绍什么是视频、音频、编解码和容器，然后我们将尝试使用 FFmpeg 命令行工具，最终使用代码实现一些功能。如果你拥有一些经验，可以随时跳过这些内容，直接阅读 [笨办法学 FFmpeg libav](#笨办法学-FFmpeg-libav) 章节。
 

--- a/README-es.md
+++ b/README-es.md
@@ -7,7 +7,7 @@ Estaba buscando un tutorial/libro que pudiera enseñarme como usar [FFmpeg](http
 
 
 
-La mayoría del código aquí estará en C, **pero no te preocupes**: tu podrás entenderlo fácilmente y aplicarlo a tu lenguaje preferido. FFmpeg libav tiene montones de bindings para muchos lenguajes como [python](https://mikeboers.github.io/PyAV/), [go](https://github.com/imkira/go-libav) e incluso si tu lenguaje no lo tiene, aún es posible darle soporte mediante `ffi` (aquí hay un ejemplo en [Lua](https://github.com/daurnimator/ffmpeg-lua-ffi/blob/master/init.lua)).
+La mayoría del código aquí estará en C, **pero no te preocupes**: tu podrás entenderlo fácilmente y aplicarlo a tu lenguaje preferido. FFmpeg libav tiene montones de bindings para muchos lenguajes como [python](https://pyav.org/), [go](https://github.com/imkira/go-libav) e incluso si tu lenguaje no lo tiene, aún es posible darle soporte mediante `ffi` (aquí hay un ejemplo en [Lua](https://github.com/daurnimator/ffmpeg-lua-ffi/blob/master/init.lua)).
 
 Empezaremos con una lección rápida de lo que es video, audio, códec y contenedor,  entonces iremos a un curso rápido en como usar el comando `FFmpeg` y finalmente, escribiremos algo de código, siéntete libre de saltar directamente[ ](http://newmediarockstars.com/wp-content/uploads/2015/11/nintendo-direct-iwata.jpg "Secret Leandro´s Easter Egg")a la sección [Aprender FFmpeg libav de la manera difícil.](#learn-ffmpeg-libav-the-hard-way) 
 

--- a/README-ko.md
+++ b/README-ko.md
@@ -4,7 +4,7 @@
 하지만 안타깝게도 그건 더이상 관리가 안되고 있어서 이 글을 쓰기로 결정했습니다.
 
 여기서 사용된 대부분의 코드는 C로 되어있습니다. **하지만 걱정하지 마세요**: 당신도 쉽게 이해할 것이고 선호하는 언어에도 적용하실 수 있을겁니다.
-FFmpeg libav는 [python](https://mikeboers.github.io/PyAV/), [go](https://github.com/imkira/go-libav)와 같은 다양한 언어로 된 많은 bindings을 제공합니다. 만약 사용하려는 언어에 그것이 없다면 `ffi`를 통해서도 지원할 수 있습니다. ([Lua](https://github.com/daurnimator/ffmpeg-lua-ffi/blob/master/init.lua) 예시)
+FFmpeg libav는 [python](https://pyav.org/), [go](https://github.com/imkira/go-libav)와 같은 다양한 언어로 된 많은 bindings을 제공합니다. 만약 사용하려는 언어에 그것이 없다면 `ffi`를 통해서도 지원할 수 있습니다. ([Lua](https://github.com/daurnimator/ffmpeg-lua-ffi/blob/master/init.lua) 예시)
 
 우리는 비디오와 오디오, 코덱, 컨테이너가 무엇인지에 대해 빠르게 학습한 후에 `FFmpeg` 명령을 어떻게 사용하는지 대해서 파헤쳐보고 마지막으로 코드도 작성해볼 것입니다, [삽질하면서 FFmpeg libav 배우기](#삽질하면서-FFmpeg-libav-배우기) 섹션으로 바로 넘어가셔도 좋습니다.
 

--- a/README-vn.md
+++ b/README-vn.md
@@ -4,7 +4,7 @@ Tôi đang tìm một bài hướng dẫn về cách sử dụng [FFmpeg](https:
 Thật không may, nó không còn được dùng nữa, vì vậy tôi quyết định viết bài hướng dẫn này.
 
 Tất cả dòng code ở đây được viết bằng ngôn ngữ C, nhưng đừng lo lắng: bạn có thể dễ dàng hiểu và áp dụng nó với ngôn ngữ bạn mong muốn.
-Thư viện FFmpeg libav có rất nhiều biến thể cho các ngôn ngữ khác nhau như [python](https://mikeboers.github.io/PyAV/), [go](https://github.com/imkira/go-libav) và thậm chí nếu ngôn ngữ bạn sử dụng không có thư viện này, bạn vẫn được hỗ trợ qua `ffi` (đây là một ví dụ với [Lua](https://github.com/daurnimator/ffmpeg-lua-ffi/blob/master/init.lua)).
+Thư viện FFmpeg libav có rất nhiều biến thể cho các ngôn ngữ khác nhau như [python](https://pyav.org/), [go](https://github.com/imkira/go-libav) và thậm chí nếu ngôn ngữ bạn sử dụng không có thư viện này, bạn vẫn được hỗ trợ qua `ffi` (đây là một ví dụ với [Lua](https://github.com/daurnimator/ffmpeg-lua-ffi/blob/master/init.lua)).
 
 Chúng ta sẽ bắt đầu với một tiết học nhanh về video, audio, codec và container; tiếp đó, chúng ta đi vào khoá học sâu hơn về cách sử dụng câu lệnh `FFmpeg` và cuối cùng chúng ta sẽ viết code. Đừng ngại bỏ qua phần đầu và nhảy thẳng đến phần [Tìm hiểu thư viện FFmpeg libav sâu hơn.](#learn-ffmpeg-libav-the-hard-way).
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ I was looking for a tutorial/book that would teach me how to start to use [FFmpe
 Unfortunately it was deprecated, so I decided to write this one.
 
 Most of the code in here will be in C **but don't worry**: you can easily understand and apply it to your preferred language.
-FFmpeg libav has lots of bindings for many languages like [python](https://mikeboers.github.io/PyAV/), [go](https://github.com/imkira/go-libav) and even if your language doesn't have it, you can still support it through the `ffi` (here's an example with [Lua](https://github.com/daurnimator/ffmpeg-lua-ffi/blob/master/init.lua)).
+FFmpeg libav has lots of bindings for many languages like [python](https://pyav.org/), [go](https://github.com/imkira/go-libav) and even if your language doesn't have it, you can still support it through the `ffi` (here's an example with [Lua](https://github.com/daurnimator/ffmpeg-lua-ffi/blob/master/init.lua)).
 
 We'll start with a quick lesson about what is video, audio, codec and container and then we'll go to a crash course on how to use `FFmpeg` command line and finally we'll write code, feel free to skip directly to[ ](http://newmediarockstars.com/wp-content/uploads/2015/11/nintendo-direct-iwata.jpg)the section [Learn FFmpeg libav the Hard Way.](#learn-ffmpeg-libav-the-hard-way)
 


### PR DESCRIPTION
Current link to PyAV (https://mikeboers.github.io/PyAV/) raises error 404,
instead use link to https://pyav.org/.