### PR TITLE
Fix deprecated/removed audio channel apis

### DIFF
--- a/0_hello_world.c
+++ b/0_hello_world.c
@@ -120,7 +120,7 @@ int main(int argc, const char *argv[])
 
       logging("Video Codec: resolution %d x %d", pLocalCodecParameters->width, pLocalCodecParameters->height);
     } else if (pLocalCodecParameters->codec_type == AVMEDIA_TYPE_AUDIO) {
-      logging("Audio Codec: %d channels, sample rate %d", pLocalCodecParameters->channels, pLocalCodecParameters->sample_rate);
+      logging("Audio Codec: %d channels, sample rate %d", pLocalCodecParameters->ch_layout.nb_channels, pLocalCodecParameters->sample_rate);
     }
 
     // print its name, id and bitrate

--- a/3_transcoding.c
+++ b/3_transcoding.c
@@ -122,8 +122,7 @@ int prepare_audio_encoder(StreamingContext *sc, int sample_rate, StreamingParams
 
   int OUTPUT_CHANNELS = 2;
   int OUTPUT_BIT_RATE = 196000;
-  sc->audio_avcc->channels       = OUTPUT_CHANNELS;
-  sc->audio_avcc->channel_layout = av_get_default_channel_layout(OUTPUT_CHANNELS);
+  av_channel_layout_default(&sc->audio_avcc->ch_layout, OUTPUT_CHANNELS);
   sc->audio_avcc->sample_rate    = sample_rate;
   sc->audio_avcc->sample_fmt     = sc->audio_avc->sample_fmts[0];
   sc->audio_avcc->bit_rate       = OUTPUT_BIT_RATE;

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN     apt-get -yqq update && \
 
 FROM base as build
 
-ENV         FFMPEG_VERSION=4.4 \
+ENV         FFMPEG_VERSION=8.0 \
             AOM_VERSION=v1.0.0 \
             FDKAAC_VERSION=0.1.5 \
             FONTCONFIG_VERSION=2.12.4 \

--- a/README-cn.md
+++ b/README-cn.md
@@ -353,7 +353,7 @@ AVCodec *pLocalCodec = avcodec_find_decoder(pLocalCodecParameters->codec_id);
 if (pLocalCodecParameters->codec_type == AVMEDIA_TYPE_VIDEO) {
   printf("Video Codec: resolution %d x %d", pLocalCodecParameters->width, pLocalCodecParameters->height);
 } else if (pLocalCodecParameters->codec_type == AVMEDIA_TYPE_AUDIO) {
-  printf("Audio Codec: %d channels, sample rate %d", pLocalCodecParameters->channels, pLocalCodecParameters->sample_rate);
+  printf("Audio Codec: %d channels, sample rate %d", pLocalCodecParameters->ch_layout.nb_channels, pLocalCodecParameters->sample_rate);
 }
 // 通用
 printf("\tCodec %s ID %d bit_rate %lld", pLocalCodec->long_name, pLocalCodec->id, pCodecParameters->bit_rate);

--- a/README-es.md
+++ b/README-es.md
@@ -374,7 +374,7 @@ Ahora, vamos a imprimir la información acerca de los códecs.
 if (pLocalCodecParameters->codec_type == AVMEDIA_TYPE_VIDEO) {
   printf("Video Codec: resolution %d x %d", pLocalCodecParameters->width, pLocalCodecParameters->height);
 } else if (pLocalCodecParameters->codec_type == AVMEDIA_TYPE_AUDIO) {
-  printf("Audio Codec: %d channels, sample rate %d", pLocalCodecParameters->channels, pLocalCodecParameters->sample_rate);
+  printf("Audio Codec: %d channels, sample rate %d", pLocalCodecParameters->ch_layout.nb_channels, pLocalCodecParameters->sample_rate);
 }
 // general
 printf("\tCodec %s ID %d bit_rate %lld", pLocalCodec->long_name, pLocalCodec->id, pLocalCodecParameters->bit_rate);

--- a/README-ko.md
+++ b/README-ko.md
@@ -354,7 +354,7 @@ AVCodec *pLocalCodec = avcodec_find_decoder(pLocalCodecParameters->codec_id);
 if (pLocalCodecParameters->codec_type == AVMEDIA_TYPE_VIDEO) {
   printf("Video Codec: resolution %d x %d", pLocalCodecParameters->width, pLocalCodecParameters->height);
 } else if (pLocalCodecParameters->codec_type == AVMEDIA_TYPE_AUDIO) {
-  printf("Audio Codec: %d channels, sample rate %d", pLocalCodecParameters->channels, pLocalCodecParameters->sample_rate);
+  printf("Audio Codec: %d channels, sample rate %d", pLocalCodecParameters->ch_layout.nb_channels, pLocalCodecParameters->sample_rate);
 }
 // general
 printf("\tCodec %s ID %d bit_rate %lld", pLocalCodec->long_name, pLocalCodec->id, pLocalCodecParameters->bit_rate);

--- a/README-pt.md
+++ b/README-pt.md
@@ -358,7 +358,7 @@ Agora podemos imprimir informações sobre os codecs.
 if (pLocalCodecParameters->codec_type == AVMEDIA_TYPE_VIDEO) {
 	printf("Video Codec: resolution %d x %d", pLocalCodecParameters->width, pLocalCodecParameters->height);
 } else if (pLocalCodecParameters->codec_type == AVMEDIA_TYPE_AUDIO) {
-	printf("Audio Codec: %d channels, sample rate %d", pLocalCodecParameters->channels, pLocalCodecParameters->sample_rate);
+	printf("Audio Codec: %d channels, sample rate %d", pLocalCodecParameters->ch_layout.nb_channels, pLocalCodecParameters->sample_rate);
 }
 // geral
 printf("\tCodec %s ID %d bit_rate %lld", pLocalCodec->long_name, pLocalCodec->id, pLocalCodecParameters->bit_rate);

--- a/README-ru.md
+++ b/README-ru.md
@@ -381,7 +381,7 @@ AVCodec *pLocalCodec = avcodec_find_decoder(pLocalCodecParameters->codec_id);
 if (pLocalCodecParameters->codec_type == AVMEDIA_TYPE_VIDEO) {
   printf("Video Codec: resolution %d x %d", pLocalCodecParameters->width, pLocalCodecParameters->height);
 } else if (pLocalCodecParameters->codec_type == AVMEDIA_TYPE_AUDIO) {
-  printf("Audio Codec: %d channels, sample rate %d", pLocalCodecParameters->channels, pLocalCodecParameters->sample_rate);
+  printf("Audio Codec: %d channels, sample rate %d", pLocalCodecParameters->ch_layout.nb_channels, pLocalCodecParameters->sample_rate);
 }
 // общее
 printf("\tCodec %s ID %d bit_rate %lld", pLocalCodec->long_name, pLocalCodec->id, pLocalCodecParameters->bit_rate);

--- a/README-vn.md
+++ b/README-vn.md
@@ -358,7 +358,7 @@ AVCodec *pLocalCodec = avcodec_find_decoder(pLocalCodecParameters->codec_id);
 if (pLocalCodecParameters->codec_type == AVMEDIA_TYPE_VIDEO) {
   printf("Video Codec: resolution %d x %d", pLocalCodecParameters->width, pLocalCodecParameters->height);
 } else if (pLocalCodecParameters->codec_type == AVMEDIA_TYPE_AUDIO) {
-  printf("Audio Codec: %d channels, sample rate %d", pLocalCodecParameters->channels, pLocalCodecParameters->sample_rate);
+  printf("Audio Codec: %d channels, sample rate %d", pLocalCodecParameters->ch_layout.nb_channels, pLocalCodecParameters->sample_rate);
 }
 // general
 printf("\tCodec %s ID %d bit_rate %lld", pLocalCodec->long_name, pLocalCodec->id, pLocalCodecParameters->bit_rate);

--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ Now we can print information about the codecs.
 if (pLocalCodecParameters->codec_type == AVMEDIA_TYPE_VIDEO) {
   printf("Video Codec: resolution %d x %d", pLocalCodecParameters->width, pLocalCodecParameters->height);
 } else if (pLocalCodecParameters->codec_type == AVMEDIA_TYPE_AUDIO) {
-  printf("Audio Codec: %d channels, sample rate %d", pLocalCodecParameters->channels, pLocalCodecParameters->sample_rate);
+  printf("Audio Codec: %d channels, sample rate %d", pLocalCodecParameters->ch_layout.nb_channels, pLocalCodecParameters->sample_rate);
 }
 // general
 printf("\tCodec %s ID %d bit_rate %lld", pLocalCodec->long_name, pLocalCodec->id, pLocalCodecParameters->bit_rate);


### PR DESCRIPTION
This tutorial really helped me a lot, thanks. I am following along with the latest ffmpeg 8.1, and here are some code fix for the removed apis. This also closes #140 